### PR TITLE
Add VideoToolbox hw decode path

### DIFF
--- a/src/lib/ffmpeg.cc
+++ b/src/lib/ffmpeg.cc
@@ -35,6 +35,7 @@
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
+#include <libavutil/hwcontext.h>
 #include <libswscale/swscale.h>
 }
 #include <boost/algorithm/string.hpp>
@@ -67,16 +68,17 @@ FFmpeg::~FFmpeg ()
 {
 	boost::mutex::scoped_lock lm (_mutex);
 
-	for (auto& i: _codec_context) {
-		avcodec_free_context (&i);
-	}
+        for (auto& i: _codec_context) {
+                avcodec_free_context (&i);
+        }
 
 	av_frame_free (&_video_frame);
 	for (auto& audio_frame: _audio_frame) {
 		av_frame_free (&audio_frame.second);
 	}
 
-	avformat_close_input (&_format_context);
+        avformat_close_input (&_format_context);
+        av_buffer_unref (&_hw_device_ctx);
 }
 
 
@@ -110,10 +112,17 @@ FFmpeg::setup_general ()
 	_format_context->pb = _avio_context;
 
 	AVDictionary* options = nullptr;
-	int e = avformat_open_input (&_format_context, 0, 0, &options);
-	if (e < 0) {
-		throw OpenFileError (_ffmpeg_content->path(0).string(), e, OpenFileError::READ);
-	}
+        int e = avformat_open_input (&_format_context, 0, 0, &options);
+        if (e < 0) {
+                throw OpenFileError (_ffmpeg_content->path(0).string(), e, OpenFileError::READ);
+        }
+
+        /* Try to create a VideoToolbox device for hardware decoding */
+        e = av_hwdevice_ctx_create (&_hw_device_ctx, AV_HWDEVICE_TYPE_VIDEOTOOLBOX, NULL, NULL, 0);
+        if (e < 0) {
+                dcpomatic_log->log (String::compose ("Failed to create hardware device: %1", e), LogEntry::TYPE_WARNING);
+                _hw_device_ctx = nullptr;
+        }
 
 	if (avformat_find_stream_info (_format_context, 0) < 0) {
 		throw DecodeError (_("could not find stream information"));
@@ -211,9 +220,16 @@ FFmpeg::setup_decoders ()
 			*/
 			av_dict_set_int (&options, "strict", FF_COMPLIANCE_EXPERIMENTAL, 0);
 			/* Enable following of links in files */
-			av_dict_set_int (&options, "enable_drefs", 1, 0);
+                        av_dict_set_int (&options, "enable_drefs", 1, 0);
 
-			r = avcodec_open2 (context, codec, &options);
+                        if (_hw_device_ctx) {
+                                context->hw_device_ctx = av_buffer_ref (_hw_device_ctx);
+                                if (!context->hw_device_ctx) {
+                                        throw std::bad_alloc();
+                                }
+                        }
+
+                        r = avcodec_open2 (context, codec, &options);
 			if (r < 0) {
 				throw DecodeError (N_("avcodec_open2"), N_("FFmpeg::setup_decoders"), r);
 			}

--- a/src/lib/ffmpeg.h
+++ b/src/lib/ffmpeg.h
@@ -38,6 +38,7 @@ struct AVFormatContext;
 struct AVFrame;
 struct AVStream;
 struct AVIOContext;
+struct AVBufferRef;
 
 class FFmpegContent;
 class FFmpegAudioStream;
@@ -73,8 +74,9 @@ protected:
 	AVIOContext* _avio_context = nullptr;
 	FileGroup _file_group;
 
-	AVFormatContext* _format_context = nullptr;
-	std::vector<AVCodecContext*> _codec_context;
+        AVFormatContext* _format_context = nullptr;
+        AVBufferRef* _hw_device_ctx = nullptr;
+        std::vector<AVCodecContext*> _codec_context;
 
 	/** AVFrame used for decoding video */
 	AVFrame* _video_frame = nullptr;

--- a/src/lib/ffmpeg_decoder.cc
+++ b/src/lib/ffmpeg_decoder.cc
@@ -52,6 +52,8 @@
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
+#include <libavutil/hwcontext.h>
+#include <libavutil/pixfmt.h>
 }
 #include <boost/algorithm/string.hpp>
 #include <iomanip>
@@ -593,19 +595,35 @@ FFmpegDecoder::decode_and_process_video_packet (AVPacket* packet)
 		/* EAGAIN means we should call avcodec_receive_frame and then re-send the same packet */
 		pending = r == AVERROR(EAGAIN);
 
-		while (true) {
-			r = avcodec_receive_frame (context, _video_frame);
-			if (r == AVERROR(EAGAIN) || r == AVERROR_EOF || (r < 0 && !packet)) {
-				/* More input is required, no more frames are coming, or we are flushing and there was
-				 * some error which we just want to ignore.
-				 */
-				return false;
-			} else if (r < 0) {
-				throw DecodeError (N_("avcodec_receive_frame"), N_("FFmpeg::decode_and_process_video_packet"), r);
-			}
+                while (true) {
+                        r = avcodec_receive_frame (context, _video_frame);
+                        if (r == AVERROR(EAGAIN) || r == AVERROR_EOF || (r < 0 && !packet)) {
+                                /* More input is required, no more frames are coming, or we are flushing and there was
+                                 * some error which we just want to ignore.
+                                 */
+                                return false;
+                        } else if (r < 0) {
+                                throw DecodeError (N_("avcodec_receive_frame"), N_("FFmpeg::decode_and_process_video_packet"), r);
+                        }
 
-			process_video_frame ();
-		}
+                        if (_video_frame->format == AV_PIX_FMT_VIDEOTOOLBOX) {
+                                AVFrame* sw_frame = av_frame_alloc();
+                                if (!sw_frame) {
+                                        throw std::bad_alloc();
+                                }
+                                int tr = av_hwframe_transfer_data(sw_frame, _video_frame, 0);
+                                if (tr < 0) {
+                                        LOG_WARNING("av_hwframe_transfer_data returned %1", tr);
+                                        av_frame_free(&sw_frame);
+                                        continue;
+                                }
+                                av_frame_unref(_video_frame);
+                                av_frame_move_ref(_video_frame, sw_frame);
+                                av_frame_free(&sw_frame);
+                        }
+
+                        process_video_frame ();
+                }
 	} while (pending);
 
 	return true;


### PR DESCRIPTION
## Summary
- create `_hw_device_ctx` for VideoToolbox hardware decode
- set up the device context when opening FFmpeg input
- pass the device to decoders and unref on destruction
- copy VideoToolbox frames to system memory during decoding

## Testing
- `./waf configure --disable-gui --disable-tests` *(fails: Checking for 'samplerate' : not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd8f71150832ea981bbdd81eeaf5e