### PR TITLE
Add VideoToolbox flag

### DIFF
--- a/src/lib/config.cc
+++ b/src/lib/config.cc
@@ -106,10 +106,11 @@ Config::set_defaults()
 	_tms_password = "";
 	_allow_any_dcp_frame_rate = false;
 	_allow_any_container = false;
-	_allow_96khz_audio = false;
-	_use_all_audio_channels = false;
-	_show_experimental_audio_processors = false;
-	_language = optional<string>();
+        _allow_96khz_audio = false;
+        _use_all_audio_channels = false;
+        _show_experimental_audio_processors = false;
+        _use_videotoolbox = false;
+        _language = optional<string>();
 	_default_still_length = 10;
 	_default_dcp_content_type = DCPContentType::from_isdcf_name("FTR");
 	_default_dcp_audio_channels = 8;
@@ -463,8 +464,9 @@ try
 	_allow_any_dcp_frame_rate = f.optional_bool_child("AllowAnyDCPFrameRate").get_value_or(false);
 	_allow_any_container = f.optional_bool_child("AllowAnyContainer").get_value_or(false);
 	_allow_96khz_audio = f.optional_bool_child("Allow96kHzAudio").get_value_or(false);
-	_use_all_audio_channels = f.optional_bool_child("UseAllAudioChannels").get_value_or(false);
-	_show_experimental_audio_processors = f.optional_bool_child("ShowExperimentalAudioProcessors").get_value_or(false);
+        _use_all_audio_channels = f.optional_bool_child("UseAllAudioChannels").get_value_or(false);
+        _show_experimental_audio_processors = f.optional_bool_child("ShowExperimentalAudioProcessors").get_value_or(false);
+        _use_videotoolbox = f.optional_bool_child("UseVideoToolbox").get_value_or(false);
 
 	_log_types = f.optional_number_child<int>("LogTypes").get_value_or(LogEntry::TYPE_GENERAL | LogEntry::TYPE_WARNING | LogEntry::TYPE_ERROR);
 	_analyse_ebur128 = f.optional_bool_child("AnalyseEBUR128").get_value_or(true);
@@ -888,9 +890,11 @@ Config::write_config() const
 	/* [XML] Allow96kHzAudio 1 to allow users to make DCPs with 96kHz audio, 0 to always make 48kHz DCPs */
 	cxml::add_text_child(root, "Allow96kHzAudio", _allow_96khz_audio ? "1" : "0");
 	/* [XML] UseAllAudioChannels 1 to allow users to map audio to all 16 DCP channels, 0 to limit to the channels used in standard DCPs */
-	cxml::add_text_child(root, "UseAllAudioChannels", _use_all_audio_channels ? "1" : "0");
-	/* [XML] ShowExperimentalAudioProcessors 1 to offer users the (experimental) audio upmixer processors, 0 to hide them */
-	cxml::add_text_child(root, "ShowExperimentalAudioProcessors", _show_experimental_audio_processors ? "1" : "0");
+        cxml::add_text_child(root, "UseAllAudioChannels", _use_all_audio_channels ? "1" : "0");
+        /* [XML] ShowExperimentalAudioProcessors 1 to offer users the (experimental) audio upmixer processors, 0 to hide them */
+        cxml::add_text_child(root, "ShowExperimentalAudioProcessors", _show_experimental_audio_processors ? "1" : "0");
+        /* [XML] UseVideoToolbox 1 to use Apple's VideoToolbox for H.264 encoding if available */
+        cxml::add_text_child(root, "UseVideoToolbox", _use_videotoolbox ? "1" : "0");
 	/* [XML] LogTypes Types of logging to write; a bitfield where 1 is general notes, 2 warnings, 4 errors, 8 debug information related
 	   to 3D, 16 debug information related to encoding, 32 debug information for timing purposes, 64 debug information related
 	   to sending email, 128 debug information related to the video view, 256 information about disk writing, 512 debug information

--- a/src/lib/config.h
+++ b/src/lib/config.h
@@ -202,9 +202,13 @@ public:
 		return _use_all_audio_channels;
 	}
 
-	bool show_experimental_audio_processors() const {
-		return _show_experimental_audio_processors;
-	}
+        bool show_experimental_audio_processors() const {
+                return _show_experimental_audio_processors;
+        }
+
+        bool use_videotoolbox() const {
+                return _use_videotoolbox;
+        }
 
 	boost::optional<std::string> language() const {
 		return _language;
@@ -764,9 +768,13 @@ public:
 		maybe_set(_use_all_audio_channels, a);
 	}
 
-	void set_show_experimental_audio_processors(bool e) {
-		maybe_set(_show_experimental_audio_processors, e, SHOW_EXPERIMENTAL_AUDIO_PROCESSORS);
-	}
+        void set_show_experimental_audio_processors(bool e) {
+                maybe_set(_show_experimental_audio_processors, e, SHOW_EXPERIMENTAL_AUDIO_PROCESSORS);
+        }
+
+        void set_use_videotoolbox(bool u) {
+                maybe_set(_use_videotoolbox, u);
+        }
 
 	void set_language(std::string l) {
 		if (_language && _language.get() == l) {
@@ -1366,11 +1374,13 @@ private:
 	    DCPs at 25fps but will play 16:9, so this is very useful for some users.
 	    https://www.dcpomatic.com/forum/viewtopic.php?f=2&t=1119&p=4468
 	*/
-	bool _allow_any_container;
-	bool _allow_96khz_audio;
-	bool _use_all_audio_channels;
-	/** Offer the upmixers in the audio processor settings */
-	bool _show_experimental_audio_processors;
+        bool _allow_any_container;
+        bool _allow_96khz_audio;
+        bool _use_all_audio_channels;
+        /** Offer the upmixers in the audio processor settings */
+        bool _show_experimental_audio_processors;
+        /** Use Apple's VideoToolbox for H.264 encoding */
+        bool _use_videotoolbox;
 	boost::optional<std::string> _language;
  	/** Default length of still image content (seconds) */
 	int _default_still_length;

--- a/src/lib/encode_cli.cc
+++ b/src/lib/encode_cli.cc
@@ -98,9 +98,10 @@ help(function <void (string)> out)
 	out("                                      (deprecated - use the dump command instead)\n");
 	out("      --no-check                    don't check project's content files for changes before making the DCP\n");
 	out("      --export-format <format>      export project to a file, rather than making a DCP: specify mov or mp4\n");
-	out("      --export-filename <filename>  filename to export to with --export-format\n");
-	out("      --hints                       analyze film for hints before encoding and abort if any are found\n");
-	out("\ne.g.\n");
+        out("      --export-filename <filename>  filename to export to with --export-format\n");
+        out("      --hints                       analyze film for hints before encoding and abort if any are found\n");
+        out("      --videotoolbox                use Apple's VideoToolbox for H.264 encoding\n");
+        out("\ne.g.\n");
 	out(fmt::format("\n  {} -t 4 make-dcp my_great_movie\n", program_name));
 	out(fmt::format("\n  {} config grok-licence 12345ABCD\n", program_name));
 	out("\n");
@@ -285,10 +286,11 @@ encode_cli(int argc, char* argv[], function<void (string)> out, function<void ()
 	bool dcp_path = false;
 	optional<boost::filesystem::path> config;
 	bool check = true;
-	optional<string> export_format;
-	optional<boost::filesystem::path> export_filename;
-	bool hints = false;
-	string command = "make-dcp";
+        optional<string> export_format;
+        optional<boost::filesystem::path> export_filename;
+        bool hints = false;
+        bool videotoolbox_flag = false;
+        string command = "make-dcp";
 
 	/* This makes it possible to call getopt several times in the same executable, for tests */
 	optind = 0;
@@ -311,13 +313,14 @@ encode_cli(int argc, char* argv[], function<void (string)> out, function<void ()
 			/* Just using A, B, C ... from here on */
 			{ "dump", no_argument, 0, 'A' },
 			{ "no-check", no_argument, 0, 'B' },
-			{ "export-format", required_argument, 0, 'C' },
-			{ "export-filename", required_argument, 0, 'D' },
-			{ "hints", no_argument, 0, 'E' },
-			{ 0, 0, 0, 0 }
-		};
+                        { "export-format", required_argument, 0, 'C' },
+                        { "export-filename", required_argument, 0, 'D' },
+                        { "hints", no_argument, 0, 'E' },
+                        { "videotoolbox", no_argument, 0, 'F' },
+                        { 0, 0, 0, 0 }
+                };
 
-		int c = getopt_long(argc, argv, "vhfnrt:j:kAs:ldc:BC:D:E", long_options, &option_index);
+                int c = getopt_long(argc, argv, "vhfnrt:j:kAs:ldc:BC:D:EF", long_options, &option_index);
 
 		if (c == -1) {
 			break;
@@ -373,11 +376,14 @@ encode_cli(int argc, char* argv[], function<void (string)> out, function<void ()
 		case 'D':
 			export_filename = optarg;
 			break;
-		case 'E':
-			hints = true;
-			break;
-		}
-	}
+                case 'E':
+                        hints = true;
+                        break;
+                case 'F':
+                        videotoolbox_flag = true;
+                        break;
+                }
+        }
 
 	vector<string> commands = {
 		"make-dcp",
@@ -501,9 +507,13 @@ encode_cli(int argc, char* argv[], function<void (string)> out, function<void ()
 		new JSONServer(json_port.get());
 	}
 
-	if (threads) {
-		Config::instance()->set_master_encoding_threads(threads.get());
-	}
+        if (threads) {
+                Config::instance()->set_master_encoding_threads(threads.get());
+        }
+
+        if (videotoolbox_flag) {
+                Config::instance()->set_use_videotoolbox(true);
+        }
 
 	shared_ptr<Film> film;
 	try {


### PR DESCRIPTION
## Summary
- add `use_videotoolbox` configuration option
- load/save the option in config XML
- expose `--videotoolbox` in `dcpomatic` CLI

## Testing
- `./waf configure` *(fails: Package samplerate was not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd968f8c0832e86f69004dece712e